### PR TITLE
ENT-6091 | Update dependencies.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,3 @@
+.idea/
+composer.lock
+/vendor

--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,5 @@
 .idea/
 composer.lock
 /vendor
+.phpunit.result.cache
+/build

--- a/.travis.yml
+++ b/.travis.yml
@@ -19,3 +19,4 @@ script:
   - vendor/bin/phpunit
   - vendor/bin/phpcs -s --report-width=120 --standard=PSR2 ./{src,tests}
   - vendor/bin/phpmd src text cleancode,codesize,controversial,design,naming,unusedcode
+  - vendor/bin/phpmd tests text cleancode,codesize,controversial,design,naming,unusedcode

--- a/.travis.yml
+++ b/.travis.yml
@@ -6,17 +6,31 @@ php:
   - 7.2
   - 7.3
 
+env:
+  - METHOD=phpunit
+  - METHOD=phpcs
+  - METHOD=phpmd
+
+
 before_script:
   - composer self-update
   - composer install
-
-# Fail if...
-# * phpunit tests fail/error
-# * phpcs tests indicate that PSR-2 compliance worsened
-# * phpmd tests indicate a mess
-script:
   - mkdir -p build/logs
-  - vendor/bin/phpunit
-  - vendor/bin/phpcs -s --report-width=120 --standard=PSR2 ./{src,tests}
-  - vendor/bin/phpmd src text cleancode,codesize,controversial,design,naming,unusedcode
-  - vendor/bin/phpmd tests text cleancode,codesize,controversial,design,naming,unusedcode
+
+script:
+  - composer run $METHOD
+
+matrix:
+  include:
+    - php: 5.6
+      env: METHOD=phpunit
+    - php: 7.1
+      env: METHOD=phpunit
+    - php: 7.2
+      env: METHOD=phpunit
+    - php: 7.3
+      env: METHOD=phpunit
+    - php: 7.3
+      env: METHOD=phpcs
+    - php: 7.3
+      env: METHOD=phpmd

--- a/.travis.yml
+++ b/.travis.yml
@@ -21,16 +21,16 @@ script:
   - composer run $METHOD
 
 matrix:
-  include:
+  exclude:
     - php: 5.6
-      env: METHOD=phpunit
-    - php: 7.1
-      env: METHOD=phpunit
-    - php: 7.2
-      env: METHOD=phpunit
-    - php: 7.3
-      env: METHOD=phpunit
-    - php: 7.3
       env: METHOD=phpcs
-    - php: 7.3
+    - php: 5.6
+      env: METHOD=phpmd
+    - php: 7.1
+      env: METHOD=phpcs
+    - php: 7.1
+      env: METHOD=phpmd
+    - php: 7.2
+      env: METHOD=phpcs
+    - php: 7.2
       env: METHOD=phpmd

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,21 @@
+language: php
+
+php:
+  - 5.6
+  - 7.1
+  - 7.2
+  - 7.3
+
+before_script:
+  - composer self-update
+  - composer install
+
+# Fail if...
+# * phpunit tests fail/error
+# * phpcs tests indicate that PSR-2 compliance worsened
+# * phpmd tests indicate a mess
+script:
+  - mkdir -p build/logs
+  - vendor/bin/phpunit
+  - vendor/bin/phpcs -s --report-width=120 --standard=PSR2 ./{src,tests}
+  - vendor/bin/phpmd src text cleancode,codesize,controversial,design,naming,unusedcode

--- a/composer.json
+++ b/composer.json
@@ -25,5 +25,8 @@
         "squizlabs/php_codesniffer": "*",
         "phpmd/phpmd": "@stable",
         "phpunit/phpunit": "^5.5 || ^6.0 || ^7.0 || ^8.0"
+    },
+    "suggest": {
+        "guzzlehttp/guzzle-services": "Use service descriptions with Guzzle."
     }
 }

--- a/composer.json
+++ b/composer.json
@@ -22,6 +22,7 @@
         "psr-4": { "Webbj74\\JSDL\\Loader\\": "src" }
     },
     "require-dev": {
-        "squizlabs/php_codesniffer": "*"
+        "squizlabs/php_codesniffer": "*",
+        "phpmd/phpmd": "@stable"
     }
 }

--- a/composer.json
+++ b/composer.json
@@ -1,6 +1,6 @@
 {
     "name": "webbj74/jsdl-loader",
-    "description": "A stand-alone JSON Service Description loader for Guzzle 5.x based on the ServiceDescriptionLoader class from Guzzle 3.x",
+    "description": "A stand-alone JSON Service Description loader for Guzzle based on the ServiceDescriptionLoader class from Guzzle 3.x",
     "homepage": "https://github.com/webbj74/jsdl-loader",
     "keywords": ["web service", "webservice", "REST", "guzzle"],
     "license": "MIT",

--- a/composer.json
+++ b/composer.json
@@ -32,8 +32,8 @@
     },
     "scripts": {
         "phpcs": [
-            "vendor/bin/phpcs -s --report-width=120 --standard=PSR2 ./{src,tests}",
-            "vendor/bin/phpcs --standard=vendor/phpcompatibility/php-compatibility/PHPCompatibility --runtime-set testVersion 5.6- ./{src,tests}"
+            "vendor/bin/phpcs -s --report-width=120 --standard=PSR2 $(git ls-files | grep -E '\\.(php|inc)$')",
+            "vendor/bin/phpcs --standard=vendor/phpcompatibility/php-compatibility/PHPCompatibility --runtime-set testVersion 5.6-  $(git ls-files | grep -E '\\.(php|inc)$')"
         ],
         "phpmd": [
             "vendor/bin/phpmd src text cleancode,codesize,controversial,design,naming,unusedcode",

--- a/composer.json
+++ b/composer.json
@@ -23,6 +23,7 @@
     },
     "require-dev": {
         "squizlabs/php_codesniffer": "*",
-        "phpmd/phpmd": "@stable"
+        "phpmd/phpmd": "@stable",
+        "phpunit/phpunit": "^5.5 || ^6.0 || ^7.0 || ^8.0"
     }
 }

--- a/composer.json
+++ b/composer.json
@@ -20,5 +20,8 @@
     },
     "autoload": {
         "psr-4": { "Webbj74\\JSDL\\Loader\\": "src" }
+    },
+    "require-dev": {
+        "squizlabs/php_codesniffer": "*"
     }
 }

--- a/composer.json
+++ b/composer.json
@@ -21,6 +21,9 @@
     "autoload": {
         "psr-4": { "Webbj74\\JSDL\\Loader\\": "src" }
     },
+    "autoload-dev": {
+        "psr-4": { "Webbj74\\JSDL\\Loader\\Tests\\": "tests" }
+    },
     "require-dev": {
         "squizlabs/php_codesniffer": "*",
         "phpmd/phpmd": "@stable",

--- a/composer.json
+++ b/composer.json
@@ -27,7 +27,21 @@
     "require-dev": {
         "squizlabs/php_codesniffer": "*",
         "phpmd/phpmd": "@stable",
-        "phpunit/phpunit": "^5.5 || ^6.0 || ^7.0 || ^8.0"
+        "phpunit/phpunit": "^5.5 || ^6.0 || ^7.0 || ^8.0",
+        "phpcompatibility/php-compatibility": "*"
+    },
+    "scripts": {
+        "phpcs": [
+            "vendor/bin/phpcs -s --report-width=120 --standard=PSR2 ./{src,tests}",
+            "vendor/bin/phpcs --standard=vendor/phpcompatibility/php-compatibility/PHPCompatibility --runtime-set testVersion 5.6- ./{src,tests}"
+        ],
+        "phpmd": [
+            "vendor/bin/phpmd src text cleancode,codesize,controversial,design,naming,unusedcode",
+            "vendor/bin/phpmd tests text cleancode,codesize,controversial,design,naming,unusedcode"
+        ],
+        "phpunit": [
+            "vendor/bin/phpunit"
+        ]
     },
     "suggest": {
         "guzzlehttp/guzzle-services": "Use service descriptions with Guzzle."

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -1,0 +1,32 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<!-- http://www.phpunit.de/manual/current/en/appendixes.configuration.html -->
+<phpunit
+    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xsi:noNamespaceSchemaLocation="http://schema.phpunit.de/4.3/phpunit.xsd"
+    backupGlobals               = "false"
+    backupStaticAttributes      = "false"
+    colors                      = "true"
+    convertErrorsToExceptions   = "true"
+    convertNoticesToExceptions  = "true"
+    convertWarningsToExceptions = "true"
+    processIsolation            = "false"
+    stopOnFailure               = "false"
+    bootstrap                   = "vendor/autoload.php" >
+
+    <testsuites>
+        <testsuite name="Main Tests">
+            <directory>tests</directory>
+        </testsuite>
+    </testsuites>
+   <filter>
+        <whitelist>
+            <directory suffix=".php">./src</directory>
+            <directory suffix=".inc">./src</directory>
+        </whitelist>
+    </filter>
+    <logging>
+        <log type="coverage-clover" target="build/logs/clover.xml"/>
+        <log type="coverage-html" target="build/report"/>
+    </logging>
+</phpunit>

--- a/src/AbstractLoader.php
+++ b/src/AbstractLoader.php
@@ -28,6 +28,11 @@ abstract class AbstractLoader implements LoaderInterface
         JSON_ERROR_UTF8 => 'JSON_ERROR_UTF8 - Malformed UTF-8 characters, possibly incorrectly encoded'
     );
 
+    /**
+     * {@inheritdoc}
+     *
+     * @SuppressWarnings(PHPMD.ElseExpression)
+     */
     public function load($config, array $options = array())
     {
         // Reset the array of loaded files because this is a new config
@@ -89,6 +94,8 @@ abstract class AbstractLoader implements LoaderInterface
      * @return array
      * @throws \InvalidArgumentException
      * @throws \RuntimeException when the JSON cannot be parsed
+     *
+     * @SuppressWarnings(PHPMD.CyclomaticComplexity)
      */
     protected function loadFile($filename)
     {

--- a/src/AbstractLoader.php
+++ b/src/AbstractLoader.php
@@ -153,9 +153,6 @@ abstract class AbstractLoader implements LoaderInterface
      *   Config data that contains includes.
      * @param string $basePath
      *   Base path to use when a relative path is encountered.
-     *
-     * @return array
-     *   Returns the merged and included data.
      */
     protected function mergeIncludes(&$config, $basePath = null)
     {

--- a/src/AbstractLoader.php
+++ b/src/AbstractLoader.php
@@ -66,7 +66,8 @@ abstract class AbstractLoader implements LoaderInterface
     /**
      * Remove an alias from the loader
      *
-     * @param string $alias Alias to remove
+     * @param string $alias
+     *   Alias to remove.
      *
      * @return self
      */
@@ -79,21 +80,29 @@ abstract class AbstractLoader implements LoaderInterface
     /**
      * Perform the parsing of a config file and create the end result
      *
-     * @param array $config  Configuration data
-     * @param array $options Options to use when building
+     * @param array $config
+     *   Array of Configuration data
+     * @param array $options
+     *   Options to use when building
      *
      * @return mixed
+     *   Array describing the service.
      */
     abstract protected function build($config, array $options);
 
     /**
      * Load a configuration file (can load JSON or PHP files that return an array when included)
      *
-     * @param string $filename File to load
+     * @param string $filename
+     *   File to load.
      *
      * @return array
+     *   Array of configuration data loaded from file.
+     *
      * @throws \InvalidArgumentException
-     * @throws \RuntimeException when the JSON cannot be parsed
+     *   When file cannot be read.
+     * @throws \RuntimeException
+     *   When the JSON cannot be parsed.
      *
      * @SuppressWarnings(PHPMD.CyclomaticComplexity)
      */
@@ -140,10 +149,13 @@ abstract class AbstractLoader implements LoaderInterface
     /**
      * Merges in all include files
      *
-     * @param array  $config   Config data that contains includes
-     * @param string $basePath Base path to use when a relative path is encountered
+     * @param array  $config
+     *   Config data that contains includes.
+     * @param string $basePath
+     *   Base path to use when a relative path is encountered.
      *
-     * @return array Returns the merged and included data
+     * @return array
+     *   Returns the merged and included data.
      */
     protected function mergeIncludes(&$config, $basePath = null)
     {

--- a/src/AbstractLoader.php
+++ b/src/AbstractLoader.php
@@ -53,7 +53,7 @@ abstract class AbstractLoader implements LoaderInterface
      * @param string $alias
      *   Filename to alias (e.g. _foo).
      * @param string $filename
-     *   Actual file to use (e.g. /path/to/foo.json).
+     *   Absolute or relative path of the file (e.g. /path/to/foo.json).
      *
      * @return self
      */

--- a/src/AbstractLoader.php
+++ b/src/AbstractLoader.php
@@ -158,13 +158,16 @@ abstract class AbstractLoader implements LoaderInterface
     /**
      * Default implementation for merging two arrays of data (uses array_merge_recursive)
      *
-     * @param array $a Original data
-     * @param array $b Data to merge into the original and overwrite existing values
+     * @param array $array1
+     *   Initial array to merge.
+     * @param array $array2
+     *   Data to merge into $array1 and overwrite existing values.
      *
      * @return array
+     *   Merged array.
      */
-    protected function mergeData(array $a, array $b)
+    protected function mergeData(array $array1, array $array2)
     {
-        return array_merge_recursive($a, $b);
+        return array_merge_recursive($array1, $array2);
     }
 }

--- a/src/AbstractLoader.php
+++ b/src/AbstractLoader.php
@@ -45,14 +45,16 @@ abstract class AbstractLoader implements LoaderInterface
     /**
      * Add an include alias to the loader
      *
-     * @param string $filename Filename to alias (e.g. _foo)
-     * @param string $alias    Actual file to use (e.g. /path/to/foo.json)
+     * @param string $alias
+     *   Filename to alias (e.g. _foo).
+     * @param string $filename
+     *   Actual file to use (e.g. /path/to/foo.json).
      *
      * @return self
      */
-    public function addAlias($filename, $alias)
+    public function addAlias($alias, $filename)
     {
-        $this->aliases[$filename] = $alias;
+        $this->aliases[$alias] = $filename;
         return $this;
     }
 

--- a/src/LoaderInterface.php
+++ b/src/LoaderInterface.php
@@ -20,8 +20,10 @@ interface LoaderInterface
     /**
      * Loads configuration data and returns an array of the loaded result
      *
-     * @param mixed $config  Data to load (filename or array of data)
-     * @param array $options Array of options to use when loading
+     * @param mixed $config
+     *   Data to load (filename or array of data).
+     * @param array $options
+     *   Array of options to use when loading.
      *
      * @return mixed
      */

--- a/src/ServiceDescriptionLoader.php
+++ b/src/ServiceDescriptionLoader.php
@@ -13,18 +13,23 @@ namespace Webbj74\JSDL\Loader;
  */
 class ServiceDescriptionLoader extends AbstractLoader
 {
+    /**
+     * {@inheritdoc}
+     *
+     * @SuppressWarnings(PHPMD.CyclomaticComplexity)
+     */
     protected function build($config, array $options)
     {
         $operations = array();
         if (!empty($config['operations'])) {
-            foreach ($config['operations'] as $name => $op) {
-                $name = $op['name'] = isset($op['name']) ? $op['name'] : $name;
+            foreach ($config['operations'] as $name => $operation) {
+                $name = $operation['name'] = isset($operation['name']) ? $operation['name'] : $name;
                 // Extend other operations
-                if (!empty($op['extends'])) {
-                    $this->resolveExtension($name, $op, $operations);
+                if (!empty($operation['extends'])) {
+                    $this->resolveExtension($name, $operation, $operations);
                 }
-                $op['parameters'] = isset($op['parameters']) ? $op['parameters'] : array();
-                $operations[$name] = $op;
+                $operation['parameters'] = isset($operation['parameters']) ? $operation['parameters'] : array();
+                $operations[$name] = $operation;
             }
         }
 

--- a/src/ServiceDescriptionLoader.php
+++ b/src/ServiceDescriptionLoader.php
@@ -43,17 +43,23 @@ class ServiceDescriptionLoader extends AbstractLoader
     }
 
     /**
-     * @param string $name       Name of the operation
-     * @param array  $op         Operation value array
-     * @param array  $operations Currently loaded operations
+     * Inherit operation values from another operation.
+     *
+     * @param string $name
+     *   Name of the operation
+     * @param array  $operation
+     *   Operation value array
+     * @param array  $operations
+     *   Currently loaded operations
+     *
      * @throws \RuntimeException when extending a non-existent operation
      */
-    protected function resolveExtension($name, array &$op, array &$operations)
+    protected function resolveExtension($name, array &$operation, array &$operations)
     {
         $resolved = array();
-        $original = empty($op['parameters']) ? false: $op['parameters'];
-        $hasClass = !empty($op['class']);
-        foreach ((array) $op['extends'] as $extendedCommand) {
+        $original = empty($operation['parameters']) ? false: $operation['parameters'];
+        $hasClass = !empty($operation['class']);
+        foreach ((array) $operation['extends'] as $extendedCommand) {
             if (empty($operations[$extendedCommand])) {
                 throw new \RuntimeException("{$name} extends missing operation {$extendedCommand}");
             }
@@ -62,11 +68,11 @@ class ServiceDescriptionLoader extends AbstractLoader
                 ? $toArray['parameters']
                 : array_merge($resolved, $toArray['parameters']);
 
-            $op = $op + $toArray;
+            $operation = $operation + $toArray;
             if (!$hasClass && isset($toArray['class'])) {
-                $op['class'] = $toArray['class'];
+                $operation['class'] = $toArray['class'];
             }
         }
-        $op['parameters'] = $original ? array_merge($resolved, $original) : $resolved;
+        $operation['parameters'] = $original ? array_merge($resolved, $original) : $resolved;
     }
 }

--- a/tests/AbstractLoaderTest.php
+++ b/tests/AbstractLoaderTest.php
@@ -10,13 +10,19 @@ use Webbj74\JSDL\Loader\AbstractLoader;
  */
 class AbstractLoaderTest extends TestCase
 {
+    /**
+     * Prefixes a file with the full path to the fixtures directory.
+     *
+     * @return string
+     *   The full path to the fixture.
+     */
     private function getFixturePath($filename)
     {
         return __DIR__ . '/fixtures/' . $filename;
     }
 
     /**
-     * @covers ::load
+     * Verify that ::load throws InvalidArgumentException if file does not exist.
      */
     public function testLoadThrowsExceptionIfFileDoesNotExist()
     {
@@ -27,7 +33,7 @@ class AbstractLoaderTest extends TestCase
     }
 
     /**
-     * @covers ::load
+     * Verify that ::load throws InvalidArgumentException if file extension is not known.
      */
     public function testLoadThrowsExceptionIfFileHasUnknownExtension()
     {
@@ -38,16 +44,41 @@ class AbstractLoaderTest extends TestCase
     }
 
     /**
-     * @covers ::load
+     *  Verify that ::load handles file argument.
      */
     public function testLoadFromFile()
     {
         $loader = $this->getMockForAbstractClass(AbstractLoader::class);
+        $loader->expects($this->once())
+            ->method('build')
+            ->with([
+                'name' => 'testLoadFromFile',
+                'apiVersion' => '0.1',
+                'description' => 'testLoadFromFile',
+            ]);
         $this->confirmValidLoaderFile($loader, $this->getFixturePath('AbstractLoaderTest_testLoadFromFile.json'));
     }
 
     /**
-     * @covers ::load
+     *  Verify that ::load handles array argument with config.
+     */
+    public function testLoadFromConfig()
+    {
+        $config = [
+            'name' => 'testLoadFromConfig',
+            'apiVersion' => '0.1',
+            'description' => 'testLoadFromConfig',
+        ];
+        $loader = $this->getMockForAbstractClass(AbstractLoader::class);
+        $loader->expects($this->once())
+            ->method('build')
+            ->with($config);
+        $this->assertNull($loader->load($config));
+    }
+
+    /**
+     * Verify that ::load throws InvalidArgumentException if given an argument it can't deal with.
+     *
      * @dataProvider badConfigProvider
      */
     public function testLoadThrowsExceptionForBadConfigArgument($config)
@@ -72,23 +103,41 @@ class AbstractLoaderTest extends TestCase
     }
 
     /**
-     * @covers ::addAlias
+     * Verify that an alias may be added.
+     *
+     * To do this we add an alias and use load to confirm that it was added.
      */
     public function testAddAlias()
     {
         $loader = $this->getMockForAbstractClass(AbstractLoader::class);
+        $loader->expects($this->once())
+            ->method('build')
+            ->with([
+                'name' => 'testAddAlias',
+                'apiVersion' => '0.1',
+                'description' => 'testAddAlias',
+            ]);
         $loader->addAlias('testAddAlias', $this->getFixturePath('AbstractLoaderTest_testAddAlias.json'));
         $this->confirmValidLoaderFile($loader, 'testAddAlias');
     }
 
     /**
-     * @covers ::removeAlias
-     * @depends testAddAlias
+     * Verify that an alias may be removed.
+     *
+     * To do this we add an alias, confirm that it was added, then expect an exception if we remove the alias.
      */
     public function testRemoveAlias()
     {
         $loader = $this->getMockForAbstractClass(AbstractLoader::class);
+        $loader->expects($this->once())
+            ->method('build')
+            ->with([
+                'name' => 'testRemoveAlias',
+                'apiVersion' => '0.1',
+                'description' => 'testRemoveAlias',
+            ]);
         $loader->addAlias('testRemoveAlias', $this->getFixturePath('AbstractLoaderTest_testRemoveAlias.json'));
+        $this->confirmValidLoaderFile($loader, 'testRemoveAlias');
         $loader->removeAlias('testRemoveAlias');
         $this->confirmInvalidLoaderFile($loader, 'testRemoveAlias');
     }

--- a/tests/AbstractLoaderTest.php
+++ b/tests/AbstractLoaderTest.php
@@ -10,14 +10,65 @@ use Webbj74\JSDL\Loader\AbstractLoader;
  */
 class AbstractLoaderTest extends TestCase
 {
+    private function getFixturePath($filename)
+    {
+        return __DIR__ . '/fixtures/' . $filename;
+    }
 
     /**
      * @covers ::load
      */
-    public function testLoad()
+    public function testLoadThrowsExceptionIfFileDoesNotExist()
     {
-        $loader = $this->getMockClass(AbstractLoader::class);
-        $result = $loader->load();
+        $loader = $this->getMockForAbstractClass(AbstractLoader::class);
+        $this->expectException(\InvalidArgumentException::class);
+        $this->expectExceptionMessageRegExp('/No such file or directory/');
+        $loader->load($this->getFixturePath('nonexistent.json'));
+    }
+
+    /**
+     * @covers ::load
+     */
+    public function testLoadThrowsExceptionIfFileHasUnknownExtension()
+    {
+        $loader = $this->getMockForAbstractClass(AbstractLoader::class);
+        $this->expectException(\InvalidArgumentException::class);
+        $this->expectExceptionMessageRegExp('/Unknown file extension/');
+        $loader->load($this->getFixturePath('bad_extension.notjson'));
+    }
+
+    /**
+     * @covers ::load
+     */
+    public function testLoadFromFile()
+    {
+        $loader = $this->getMockForAbstractClass(AbstractLoader::class);
+        $this->confirmValidLoaderFile($loader, $this->getFixturePath('AbstractLoaderTest_testLoadFromFile.json'));
+    }
+
+    /**
+     * @covers ::load
+     * @dataProvider badConfigProvider
+     */
+    public function testLoadThrowsExceptionForBadConfigArgument($config)
+    {
+        $loader = $this->getMockForAbstractClass(AbstractLoader::class);
+        $this->expectException(\InvalidArgumentException::class);
+        $loader->load($config);
+    }
+
+    /**
+     * Data provider for invalid config arguments.
+     *
+     * @return array
+     *   Series of bag arguments to provide.
+     */
+    public function badConfigProvider()
+    {
+        return [
+            'integer'  => [0],
+            'object'  => [(object)['foo' => 'bar']],
+        ];
     }
 
     /**
@@ -25,8 +76,9 @@ class AbstractLoaderTest extends TestCase
      */
     public function testAddAlias()
     {
-        $loader = $this->getMockClass(AbstractLoader::class);
-        $result = $loader->addAlias();
+        $loader = $this->getMockForAbstractClass(AbstractLoader::class);
+        $loader->addAlias('testAddAlias', $this->getFixturePath('AbstractLoaderTest_testAddAlias.json'));
+        $this->confirmValidLoaderFile($loader, 'testAddAlias');
     }
 
     /**
@@ -35,8 +87,38 @@ class AbstractLoaderTest extends TestCase
      */
     public function testRemoveAlias()
     {
-        $loader = $this->getMockClass(AbstractLoader::class);
-        $result = $loader->addAlias();
-        $result = $loader->removeAlias();
+        $loader = $this->getMockForAbstractClass(AbstractLoader::class);
+        $loader->addAlias('testRemoveAlias', $this->getFixturePath('AbstractLoaderTest_testRemoveAlias.json'));
+        $loader->removeAlias('testRemoveAlias');
+        $this->confirmInvalidLoaderFile($loader, 'testRemoveAlias');
+    }
+
+    /**
+     * Confirm ::load will throw exception if invalid filename supplied.
+     *
+     * @param Webbj74\JSDL\Loader\AbstractLoader $loader
+     *   The loader instance to test.
+     * @param string $filename
+     *   The filename to attempt to load.
+     */
+    private function confirmInvalidLoaderFile($loader, $filename)
+    {
+        $this->expectException(\InvalidArgumentException::class);
+        $this->expectExceptionMessageRegExp('/(No such file or directory|Unknown file extension)/');
+        $loader->load($filename);
+    }
+
+    /**
+     * Confirm ::load will not throw exception if valid filename supplied.
+     *
+     * @param Webbj74\JSDL\Loader\AbstractLoader $loader
+     *   The loader instance to test.
+     * @param string $filename
+     *   The filename to attempt to load.
+     */
+    private function confirmValidLoaderFile($loader, $filename)
+    {
+        // Assumes the best if no exceptions are thrown.
+        $this->assertNull($loader->load($filename));
     }
 }

--- a/tests/AbstractLoaderTest.php
+++ b/tests/AbstractLoaderTest.php
@@ -2,9 +2,10 @@
 
 namespace Webbj74\JSDL\Loader\Tests;
 
+use PHPUnit\Framework\TestCase;
 use Webbj74\JSDL\Loader\AbstractLoader;
 
-class AbstractLoaderTest extends \PHPUnit_Framework_TestCase
+class AbstractLoaderTest extends TestCase
 {
 
     public function testRemoveAlias()

--- a/tests/AbstractLoaderTest.php
+++ b/tests/AbstractLoaderTest.php
@@ -5,21 +5,38 @@ namespace Webbj74\JSDL\Loader\Tests;
 use PHPUnit\Framework\TestCase;
 use Webbj74\JSDL\Loader\AbstractLoader;
 
+/**
+ * @coversDefaultClass \Webbj74\JSDL\Loader\AbstractLoader
+ */
 class AbstractLoaderTest extends TestCase
 {
 
-    public function testRemoveAlias()
-    {
-
-    }
-
+    /**
+     * @covers ::load
+     */
     public function testLoad()
     {
-
+        $loader = $this->getMockClass(AbstractLoader::class);
+        $result = $loader->load();
     }
 
+    /**
+     * @covers ::addAlias
+     */
     public function testAddAlias()
     {
+        $loader = $this->getMockClass(AbstractLoader::class);
+        $result = $loader->addAlias();
+    }
 
+    /**
+     * @covers ::removeAlias
+     * @depends testAddAlias
+     */
+    public function testRemoveAlias()
+    {
+        $loader = $this->getMockClass(AbstractLoader::class);
+        $result = $loader->addAlias();
+        $result = $loader->removeAlias();
     }
 }

--- a/tests/AbstractLoaderTest.php
+++ b/tests/AbstractLoaderTest.php
@@ -1,0 +1,24 @@
+<?php
+
+namespace Webbj74\JSDL\Loader\Tests;
+
+use Webbj74\JSDL\Loader\AbstractLoader;
+
+class AbstractLoaderTest extends \PHPUnit_Framework_TestCase
+{
+
+    public function testRemoveAlias()
+    {
+
+    }
+
+    public function testLoad()
+    {
+
+    }
+
+    public function testAddAlias()
+    {
+
+    }
+}

--- a/tests/fixtures/AbstractLoaderTest_testAddAlias.json
+++ b/tests/fixtures/AbstractLoaderTest_testAddAlias.json
@@ -1,0 +1,5 @@
+{
+  "name": "testLoadFromFile",
+  "apiVersion": "0.1",
+  "description": "testLoadFromFile"
+}

--- a/tests/fixtures/AbstractLoaderTest_testAddAlias.json
+++ b/tests/fixtures/AbstractLoaderTest_testAddAlias.json
@@ -1,5 +1,5 @@
 {
-  "name": "testLoadFromFile",
+  "name": "testAddAlias",
   "apiVersion": "0.1",
-  "description": "testLoadFromFile"
+  "description": "testAddAlias"
 }

--- a/tests/fixtures/AbstractLoaderTest_testLoadFromFile.json
+++ b/tests/fixtures/AbstractLoaderTest_testLoadFromFile.json
@@ -1,0 +1,5 @@
+{
+  "name": "testLoadFromFile",
+  "apiVersion": "0.1",
+  "description": "testLoadFromFile"
+}

--- a/tests/fixtures/AbstractLoaderTest_testRemoveAlias.json
+++ b/tests/fixtures/AbstractLoaderTest_testRemoveAlias.json
@@ -1,5 +1,5 @@
 {
-  "name": "testLoadFromFile",
+  "name": "testRemoveAlias",
   "apiVersion": "0.1",
-  "description": "testLoadFromFile"
+  "description": "testRemoveAlias"
 }

--- a/tests/fixtures/AbstractLoaderTest_testRemoveAlias.json
+++ b/tests/fixtures/AbstractLoaderTest_testRemoveAlias.json
@@ -1,0 +1,5 @@
+{
+  "name": "testLoadFromFile",
+  "apiVersion": "0.1",
+  "description": "testLoadFromFile"
+}


### PR DESCRIPTION
Although this package is not dependent on any other PHP packages, we currently have no way to determine if this package is compatible with a particular version of PHP. This PR introduces Travis-CI tests and some phpunit tests to allow for that. 

I used `SuppressWarning` annotations for PHP Mess Detector in a few places where safe refactoring suggests more test coverage (and this was supposed to be a quick update).
**Issue:** https://backlog.acquia.com/browse/ENT-6091
**Release Request:** https://backlog.acquia.com/browse/ENT-6161